### PR TITLE
Rename PodFile to Podfile

### DIFF
--- a/plugin/platforms/ios/PodFile
+++ b/plugin/platforms/ios/PodFile
@@ -1,1 +1,0 @@
-pod 'Google/Analytics'

--- a/plugin/platforms/ios/Podfile
+++ b/plugin/platforms/ios/Podfile
@@ -1,0 +1,1 @@
+pod 'Google/Analytics'


### PR DESCRIPTION
It doesn't work for case-sensitive FS hard drives.
It should be **Podfile** instead of ~~PodFile~~.